### PR TITLE
Revert "[FIX] clix flags are read using Global* functions. (#56)"

### DIFF
--- a/clix/log.go
+++ b/clix/log.go
@@ -11,7 +11,7 @@ import (
 
 // NewLogger creates a new logger.
 func NewLogger(c *cli.Context) (logged.Logger, error) {
-	levelStr := c.GlobalString(FlagLogLevel)
+	levelStr := c.String(FlagLogLevel)
 	if levelStr == "" {
 		levelStr = "info"
 	}
@@ -29,7 +29,7 @@ func NewLogger(c *cli.Context) (logged.Logger, error) {
 	h := logged.BufferedStreamHandler(os.Stdout, 2000, 1*time.Second, format)
 	h = logged.LevelFilterHandler(level, h)
 
-	tags, err := SplitTags(c.GlobalStringSlice(FlagLogTags), "=")
+	tags, err := SplitTags(c.StringSlice(FlagLogTags), "=")
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func NewLogger(c *cli.Context) (logged.Logger, error) {
 }
 
 func newLogFormat(c *cli.Context) (logged.Formatter, error) {
-	format := c.GlobalString(FlagLogFormat)
+	format := c.String(FlagLogFormat)
 	switch format {
 	case "terminal":
 		fmt.Println("clix: terminal format depreciated, using logfmt instead")

--- a/clix/profiler.go
+++ b/clix/profiler.go
@@ -12,12 +12,12 @@ var profilerServer = &http.Server{}
 
 // RunProfiler runs a profiler server.
 func RunProfiler(c *cli.Context) error {
-	if !c.GlobalBool(FlagProfiler) {
+	if !c.Bool(FlagProfiler) {
 		return nil
 	}
 
 	profilerServer.Handler = newProfilerMux()
-	profilerServer.Addr = ":" + c.GlobalString(FlagProfilerPort)
+	profilerServer.Addr = ":" + c.String(FlagProfilerPort)
 
 	go func() {
 		err := profilerServer.ListenAndServe()

--- a/clix/stats.go
+++ b/clix/stats.go
@@ -16,7 +16,7 @@ func NewStats(c *cli.Context, l log.Logger) (stats.Stats, error) {
 	var s stats.Stats
 	var err error
 
-	dsn := c.GlobalString(FlagStatsDSN)
+	dsn := c.String(FlagStatsDSN)
 	if dsn == "" {
 		return stats.Null, nil
 	}
@@ -43,7 +43,7 @@ func NewStats(c *cli.Context, l log.Logger) (stats.Stats, error) {
 		return nil, fmt.Errorf("Unknown scheme: %s", scheme)
 	}
 
-	tags, err := SplitTags(c.GlobalStringSlice(FlagStatsTags), "=")
+	tags, err := SplitTags(c.StringSlice(FlagStatsTags), "=")
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func NewStats(c *cli.Context, l log.Logger) (stats.Stats, error) {
 }
 
 func newStatsDStats(c *cli.Context, addr string) (stats.Stats, error) {
-	s, err := stats.NewBufferedStatsd(addr, c.GlobalString(FlagStatsPrefix), stats.WithFlushInterval(1*time.Second))
+	s, err := stats.NewBufferedStatsd(addr, c.String(FlagStatsPrefix), stats.WithFlushInterval(1*time.Second))
 	if err != nil {
 		return nil, err
 	}
@@ -61,11 +61,11 @@ func newStatsDStats(c *cli.Context, addr string) (stats.Stats, error) {
 }
 
 func newL2metStats(c *cli.Context, l log.Logger) stats.Stats {
-	return stats.NewL2met(l, c.GlobalString(FlagStatsPrefix))
+	return stats.NewL2met(l, c.String(FlagStatsPrefix))
 }
 
 func newPrometheusStats(c *cli.Context, addr string, l log.Logger) stats.Stats {
-	s := stats.NewPrometheus(c.GlobalString(FlagStatsPrefix))
+	s := stats.NewPrometheus(c.String(FlagStatsPrefix))
 
 	if addr != "" {
 		mux := http.NewServeMux()


### PR DESCRIPTION
This reverts commit 57f8d806f31043a14bb976101ca467754ee6f8b1.